### PR TITLE
Use docker bake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,7 @@
 build:
-	# Ruby 3.0
-	docker build --build-arg RUBY_VERSION=3.0 -f Dockerfile              -t nullstone/rails:ruby3.0               .
-	docker build --build-arg RUBY_VERSION=3.0 -f local.Dockerfile        -t nullstone/rails:ruby3.0-local         .
-	docker build --build-arg RUBY_VERSION=3.0 -f webapp/Dockerfile       -t nullstone/rails:webapp-ruby3.0        .
-	docker build --build-arg RUBY_VERSION=3.0 -f webapp/local.Dockerfile -t nullstone/rails:webapp-ruby3.0-local  .
-	# Ruby 3.1
-	docker build --build-arg RUBY_VERSION=3.1 -f Dockerfile              -t nullstone/rails:ruby3.1               .
-	docker build --build-arg RUBY_VERSION=3.1 -f local.Dockerfile        -t nullstone/rails:ruby3.1-local         .
-	docker build --build-arg RUBY_VERSION=3.1 -f webapp/Dockerfile       -t nullstone/rails:webapp-ruby3.1        .
-	docker build --build-arg RUBY_VERSION=3.1 -f webapp/local.Dockerfile -t nullstone/rails:webapp-ruby3.1-local  .
-
-tags:
-	# Ruby 3
-	docker tag nullstone/rails:ruby3.1       nullstone/rails:ruby3
-	docker tag nullstone/rails:ruby3.1       nullstone/rails
-	docker tag nullstone/rails:ruby3.1-local nullstone/rails:ruby3-local
-	docker tag nullstone/rails:ruby3.1-local nullstone/rails:local
-
-	docker tag nullstone/rails:webapp-ruby3.1       nullstone/rails:webapp-ruby3
-	docker tag nullstone/rails:webapp-ruby3.1       nullstone/rails:webapp
-	docker tag nullstone/rails:webapp-ruby3.1-local nullstone/rails:webapp-ruby3-local
-	docker tag nullstone/rails:webapp-ruby3.1-local nullstone/rails:webapp-local
+	docker buildx bake -f docker-bake.3-0.hcl
+	docker buildx bake -f docker-bake.3-1.hcl
 
 push:
-	docker push nullstone/rails:ruby3.0
-	docker push nullstone/rails:ruby3.0-local
-
-	docker push nullstone/rails:webapp-ruby3.0
-	docker push nullstone/rails:webapp-ruby3.0-local
-
-	docker push nullstone/rails:ruby3.1
-	docker push nullstone/rails:ruby3.1-local
-	docker push nullstone/rails:ruby3
-	docker push nullstone/rails:ruby3-local
-	docker push nullstone/rails
-	docker push nullstone/rails:local
-
-	docker push nullstone/rails:webapp-ruby3.1
-	docker push nullstone/rails:webapp-ruby3.1-local
-	docker push nullstone/rails:webapp-ruby3
-	docker push nullstone/rails:webapp-ruby3-local
-	docker push nullstone/rails:webapp
-	docker push nullstone/rails:webapp-local
+	docker buildx bake -f docker-bake.3-0.hcl --push
+	docker buildx bake -f docker-bake.3-1.hcl --push

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This image is very opinionated; however, not restrictive.
 
 - [latest, ruby3, ruby3.1](Dockerfile)
 - [local, ruby3-local, ruby3.1-local](local.Dockerfile)
-- [webapp, webapp-ruby3, webapp-ruby3.1](webapp/Dockerfile)
-- [webapp-local, webapp-ruby3-local, webapp-ruby3.1-local](webapp/local.Dockerfile)
+- [webapp, ruby3-webapp, ruby3.1-webapp](webapp/Dockerfile)
+- [webapp-local, ruby3-webapp-local, ruby3.1-webapp-local](webapp/local.Dockerfile)
 - [ruby3.0](Dockerfile)
 - [ruby3.0-local](local.Dockerfile)
-- [webapp-ruby3.0](webapp/Dockerfile)
-- [webapp-ruby3.0-local](webapp/local.Dockerfile)
+- [ruby3.0-webapp](webapp/Dockerfile)
+- [ruby3.0-webapp-local](webapp/local.Dockerfile)
 
 ## Production vs Local
 

--- a/docker-bake.3-0.hcl
+++ b/docker-bake.3-0.hcl
@@ -1,0 +1,48 @@
+group "default" {
+  targets = [
+    "ruby3-0",
+    "ruby3-0-local",
+    "ruby3-0-webapp",
+    "ruby3-0-webapp-local",
+  ]
+}
+
+target "ruby3-0" {
+  dockerfile = "Dockerfile"
+  tags      = [
+    "nullstone/rails:ruby3.0"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.0"
+  }
+}
+
+target "ruby3-0-local" {
+  dockerfile = "local.Dockerfile"
+  tags      = [
+    "nullstone/rails:ruby3.0-local"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.0"
+  }
+}
+
+target "ruby3-0-webapp" {
+  dockerfile = "webapp/Dockerfile"
+  tags      = [
+    "nullstone/rails:ruby3.0-webapp"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.0"
+  }
+}
+
+target "ruby3-0-webapp-local" {
+  dockerfile = "webapp/local.Dockerfile"
+  tags      = [
+    "nullstone/rails:ruby3.0-webapp-local"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.0"
+  }
+}

--- a/docker-bake.3-1.hcl
+++ b/docker-bake.3-1.hcl
@@ -1,0 +1,56 @@
+group "default" {
+  targets = [
+    "ruby3-1",
+    "ruby3-1-local",
+    "ruby3-1-webapp",
+    "ruby3-1-webapp-local",
+  ]
+}
+
+target "ruby3-1" {
+  dockerfile = "Dockerfile"
+  tags = [
+    "nullstone/rails:ruby3.1",
+    "nullstone/rails:ruby3",
+    "nullstone/rails",
+  ]
+  args = {
+    "RUBY_VERSION" = "3.1"
+  }
+}
+
+target "ruby3-1-local" {
+  dockerfile = "local.Dockerfile"
+  tags = [
+    "nullstone/rails:ruby3.1-local",
+    "nullstone/rails:ruby3-local",
+    "nullstone/rails:local",
+  ]
+  args = {
+    "RUBY_VERSION" = "3.1"
+  }
+}
+
+target "ruby3-1-webapp" {
+  dockerfile = "webapp/Dockerfile"
+  tags = [
+    "nullstone/rails:ruby3.1-webapp",
+    "nullstone/rails:ruby3-webapp",
+    "nullstone/rails:webapp"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.1"
+  }
+}
+
+target "ruby3-1-webapp-local" {
+  dockerfile = "webapp/Dockerfile"
+  tags = [
+    "nullstone/rails:ruby3.1-webapp-local",
+    "nullstone/rails:ruby3-webapp-local",
+    "nullstone/rails:webapp-local"
+  ]
+  args = {
+    "RUBY_VERSION" = "3.1"
+  }
+}


### PR DESCRIPTION
This switches our builds from using several Makefile targets to using a set of docker-bake.hcl files.
- Each ruby version has its own docker-bake.<ruby-version>.hcl file with all 4 targets (i.e. prod, local, webapp-prod, webapp-local)
- Tag names are consistent now (i.e. `webapp` is after the ruby version)

By using docker bake, builds for a single ruby version are performed in parallel.